### PR TITLE
Fix @return type declarations

### DIFF
--- a/src/CampfireMessage.php
+++ b/src/CampfireMessage.php
@@ -23,7 +23,7 @@ class CampfireMessage
      * https://github.com/basecamp/bc3-api/blob/master/sections/rich_text.md
      *
      * @param  string  $data
-     * @return this
+     * @return self
      */
     public function data($data)
     {
@@ -34,7 +34,7 @@ class CampfireMessage
      * Set the summary text when using details.
      *
      * @param  string  $summary
-     * @return this
+     * @return self
      */
     public function summary($summary)
     {
@@ -47,7 +47,7 @@ class CampfireMessage
      * Set the details that will be displayed in a dropdown.
      *
      * @param  string  $details
-     * @return this
+     * @return self
      */
     public function details($details)
     {


### PR DESCRIPTION
Just a very minor PR, I've been running PHPStan on my project and it's warning that `this` is an unknown return type when chaining a `CampfireMessage`. `@return this` is invalid, and causes static analysis tools to throw errors. The correct return type is `@return self`.

Thanks for a really handy package :)